### PR TITLE
Fix mongodb connection timeout config

### DIFF
--- a/checks/mongo/check.go
+++ b/checks/mongo/check.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -61,15 +60,11 @@ func (service *healthCheck) executeCheck() error {
 		return errors.New("URL is empty")
 	}
 
-	start := time.Now()
 	_, err := service.connectMongo()
-	elapsed := time.Since(start)
 
 	if err != nil {
 		return err
 	}
-
-	fmt.Println("Elapsed time: ", elapsed)
 
 	return ping(service.Config)
 }

--- a/checks/mongo/check.go
+++ b/checks/mongo/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 
 var (
 	conn              *mongo.Client
-	ConnectionTimeout = 3 * time.Second
+	ConnectionTimeout = 999 * time.Second
 	mu                sync.RWMutex
 )
 
@@ -59,10 +60,15 @@ func (service *healthCheck) executeCheck() error {
 		return errors.New("URL is empty")
 	}
 
+	start := time.Now()
 	_, err := service.connectMongo()
+	elapsed := time.Since(start)
+
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("Elapsed time: ", elapsed)
 
 	return ping()
 }

--- a/checks/mongo/check_test.go
+++ b/checks/mongo/check_test.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"testing"
+	"time"
 
 	check "github.com/mundipagg/healthcheck-go/checks"
 	"github.com/stretchr/testify/assert"
@@ -35,4 +36,14 @@ func Test_Execute_WhenConfigurationIsInvalid_ShouldReturnUnhealthy(t *testing.T)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.Status, check.Unhealthy)
 	assert.Contains(t, result.Description, "ERROR:")
+}
+
+func Test_getConnectionTimeout(t *testing.T) {
+	config := newStubMongoConfig()
+
+	assert.Equal(t, getConnectionTimeout(config), 3*time.Second)
+
+	config.ConnectionTimeout = 5
+
+	assert.Equal(t, getConnectionTimeout(config), 5*time.Second)
 }


### PR DESCRIPTION
### Fix mongodb connection timeout config

Esse PR adiciona uma variável nova para o timeout de conexão do MongoDB. O comportamento antigo estava com uma variável global com 3 segundos hardcoded, o que impedia dos usuários da lib de configurarem em suas aplicações o comportamento do timeout.

Essa correção surgiu da necessidade de corrigimos esse problema na aplicação das boleto-api em que nós estávamos recebendo uma conexão com o mongo em mais de 3 segundos, o que estourava o erro de healthcheck.

### Alterações existentes no PR:

- [ ] :ambulance: Correção de um bug crítico;
- [x] :bug: Correção de bug;
- [ ] :sparkles: Nova feature; 
- [ ] :fire: Remoção de funcionalidade ou arquivos;
- [ ] :recycle: Refatoração;
- [ ] :art: Formatação;
- [ ] :zap: Performance;
- [ ] :memo: Documentação;
- [ ] :speaker: Logs;
- [ ] :wrench: Arquivos de configuração;
- [ ] :poop: Ajuste temporário.

## Checklist

- [ ] Validei o BusinessModel e a documentação oficial (caso exista).
- [x] Eu revisei meu próprio código.
- [x] Eu realizei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
